### PR TITLE
fixed api to always send the item image

### DIFF
--- a/backend/routes/api/items.js
+++ b/backend/routes/api/items.js
@@ -86,6 +86,7 @@ router.get("/", auth.optional, function(req, res, next) {
         return res.json({
           items: await Promise.all(
             items.map(async function(item) {
+              item.image = item.image ? item.image : '/placeholder.png';
               item.seller = await User.findById(item.seller);
               return item.toJSONFor(user);
             })
@@ -164,7 +165,7 @@ router.get("/:item", auth.optional, function(req, res, next) {
   ])
     .then(function(results) {
       var user = results[0];
-
+      req.item.image = req.item.image ? req.item.image : '/placeholder.png';
       return res.json({ item: req.item.toJSONFor(user) });
     })
     .catch(next);


### PR DESCRIPTION
APIs to load list of items and a single item has been modified to always return an image.

If an image of item is present, it will be returned, otherwise placeholder image will be returned.